### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,2 @@
-declare function amendObject<T> (obj: T, items: null | undefined): T
-declare function amendObject<T, V = any> (obj: T, items: [string, V][]): T & { [key: string]: V }
-declare function amendObject<T, V = any> (obj: T, items: [number, V][]): T & { [key: number]: V }
-declare function amendObject<T, V = any> (obj: T, items: [string | number, V][]): T & { [key: string]: V, [key: number]: V }
-export = amendObject
+export default function amendObject<T extends object> (target: T, items: null | undefined): T
+export default function amendObject<T extends object, TKey extends PropertyKey = PropertyKey, TValue = any> (target: T, items: Iterable<readonly [TKey, TValue]>): T & { [key in TKey]: TValue }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-'use strict'
-
 const allowedKeyTypes = ['string', 'number', 'symbol']
 
-module.exports = function (obj, items) {
-  if (items == null) return obj
+export default function amendObject (target, items) {
+  if (items == null) return target
 
   if (typeof items[Symbol.iterator] !== 'function') {
     throw new TypeError(`Expected items to be an iterable, got ${typeof items}`)
@@ -14,12 +12,12 @@ module.exports = function (obj, items) {
       throw new TypeError(`Iterator value ${item} is not an entry object`)
     }
 
-    if (allowedKeyTypes.indexOf(typeof item[0]) === -1) {
+    if (!allowedKeyTypes.includes(typeof item[0])) {
       throw new TypeError(`Expected key to be one of types ${allowedKeyTypes.join(', ')}, got ${typeof item[0]}`)
     }
 
-    obj[item[0]] = item[1]
+    target[item[0]] = item[1]
   }
 
-  return obj
+  return target
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const allowedKeyTypes = ['string', 'number']
+const allowedKeyTypes = ['string', 'number', 'symbol']
 
 module.exports = function (obj, items) {
   if (items == null) return obj

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const allowedKeyTypes = ['string', 'number']
 
 module.exports = function (obj, items) {
-  if (items == null) return {}
+  if (items == null) return obj
 
   if (typeof items[Symbol.iterator] !== 'function') {
     throw new TypeError(`Expected items to be an iterable, got ${typeof items}`)

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,12 @@
+import { expectType } from 'tsd-check'
+import amendObject from './index.js'
+
+expectType<{ a: number }>(amendObject({ a: 1 }, null))
+expectType<{ a: number }>(amendObject({ a: 1 }, undefined))
+
+expectType<{ a: number, b: number }>(amendObject({ a: 1 }, [['b', 2]]))
+expectType<{ a: number, b: string }>(amendObject({ a: 1 }, [['b', '']]))
+
+expectType<{ a: number, b: number, c: number, d: number }>(amendObject({ a: 1 }, [['b', 2], ['c', 3], ['d', 4]]))
+
+expectType<{ a: number } & Record<any, any>>(amendObject({ a: 1 }, [['' as any, '' as any]]))

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "1.0.0",
   "license": "MIT",
   "repository": "LinusU/node-amend-object",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test && tsd-check"
   },
   "devDependencies": {
-    "standard": "^14.3.1"
+    "standard": "^16.0.3",
+    "tsd-check": "^0.6.0"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -41,4 +41,4 @@ A `TypeError` will be thrown in the following conditions:
 
 - `items` is not an iterable
 - any element in `items` is not an object (usually an array, but can be object with the keys `0` and `1`)
-- any key is not a string or a number
+- any key is not a string, a number, or a symbol

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install --save amend-object
 ## Usage
 
 ```js
-const amendObject = require('amend-object')
+import amendObject from 'amend-object'
 
 const me = {
   firstName: 'Linus',
@@ -29,9 +29,9 @@ console.log(me)
 
 ## API
 
-### `amendObject(obj, items) => object`
+### `amendObject(target, items) => object`
 
-Update object `obj` with `items`.
+Update object `target` with `items`.
 
 `items` should be an iterable (e.g. an array) where each item is a key/value pair.
 

--- a/test.js
+++ b/test.js
@@ -13,3 +13,6 @@ assert.throws(() => amendObject({}, 1337), TypeError)
 
 assert.deepStrictEqual(amendObject({ a: 1 }, undefined), { a: 1 })
 assert.deepStrictEqual(amendObject({ a: 1 }, null), { a: 1 })
+
+const symbol = Symbol('test')
+assert.deepStrictEqual(amendObject({ a: 1 }, [[symbol, 'test']]), { a: 1, [symbol]: 'test' })

--- a/test.js
+++ b/test.js
@@ -10,3 +10,6 @@ assert.strictEqual(test, returnValue)
 assert.deepStrictEqual(test, { a: 1, b: 2, c: 3 })
 
 assert.throws(() => amendObject({}, 1337), TypeError)
+
+assert.deepStrictEqual(amendObject({ a: 1 }, undefined), { a: 1 })
+assert.deepStrictEqual(amendObject({ a: 1 }, null), { a: 1 })

--- a/test.js
+++ b/test.js
@@ -1,7 +1,5 @@
-'use strict'
-
-const assert = require('assert')
-const amendObject = require('./')
+import assert from 'node:assert'
+import amendObject from './index.js'
 
 const test = { a: 1 }
 const returnValue = amendObject(test, [['b', 2], ['c', 3]])


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`